### PR TITLE
I've set a fixed height for the decode result screen and updated the …

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "flow dev decoder",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "wooncloud",
   "description": "플로우 데브 디코더",
   "background": {

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -77,7 +77,8 @@ section>div>textarea#textarea::placeholder {
 pre#jsonOutputContainer {
 	display: flex;
 	width: 100%;
-	height: 100%;
+	height: 300px;
+	overflow: auto;
 	border: 1px solid #444;
 	border-radius: 6px;
 	margin: 0;


### PR DESCRIPTION
…manifest version.

- I modified `popup.css` to set a fixed height (300px) and `overflow: auto` for the JSON output container (`pre#jsonOutputContainer`) to prevent the UI from resizing with varying content lengths.
- I incremented the extension version to 1.1.1 in `manifest.json` as you requested for testing.