### PR TITLE
feat: enhance toast UI and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "flow-dev-decoder",
+  "version": "1.0.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "flow-dev-decoder",
+      "version": "1.0.2",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-dev-decoder",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "flow dev decoder",
   "main": "index.js",
   "scripts": {

--- a/popup/js/ui.js
+++ b/popup/js/ui.js
@@ -38,13 +38,15 @@ export const showStatus = (message) => {
     clearTimeout(statusTimeoutId);
     statusTimeoutId = null;
   }
-  
+
   elements.statusLabel.innerText = message;
-  elements.statusLabel.style.display = "block";
-  
+  elements.statusLabel.classList.add('show');
+
   statusTimeoutId = setTimeout(() => {
-    elements.statusLabel.innerText = "";
-    elements.statusLabel.style.display = "none";
+    elements.statusLabel.classList.remove('show');
+    setTimeout(() => {
+      elements.statusLabel.innerText = "";
+    }, 300);
     statusTimeoutId = null;
   }, STATUS_DISPLAY_TIME);
 };
@@ -83,4 +85,4 @@ export const restoreUI = (state) => {
   } else {
     toggleOutput(false);
   }
-}; 
+};

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -137,13 +137,27 @@ button.icon-button:active {
 }
 
 div#status {
-    height: auto;
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%) translateY(20px);
     font-size: small;
     font-weight: bold;
-    color: #ddd;
-    padding-top: 0;
+    color: #fff;
+    background-color: rgba(33, 33, 33, 0.9);
+    padding: 10px 16px;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
     text-align: center;
-    display: none;
+    opacity: 0;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    z-index: 1000;
+    pointer-events: none;
+}
+
+div#status.show {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
 }
 
 #storage-status-indicator {


### PR DESCRIPTION
## Summary
- add slide-and-fade toast styling
- handle toast show/hide via `show` class
- bump package version to 1.0.2

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6895666302648324a7a66766391703b1